### PR TITLE
Página de Legislações

### DIFF
--- a/app/Http/Controllers/Site/legislacao/LegislacaoController.php
+++ b/app/Http/Controllers/Site/legislacao/LegislacaoController.php
@@ -4,27 +4,24 @@ namespace App\Http\Controllers\Site\legislacao;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
-use App\Models\Site\LegislacaoTipo;
-use App\Models\Site\Legislacao;
-use App\Models\Site\LegislacaoSituacao;
-use App\Models\Site\Parlamentar;
+use App\Repositories\LegislacaoRepository;
 
 class LegislacaoController extends Controller
 {
-    public function indexLegislacao(Request $request)
+    public function indexLegislacao(Request $request, LegislacaoRepository $legislacaoRepository)
     {
-        $legislacao['especiesNormativas'] = $this->getLegislacoesPorTipo(1);
-        $legislacao['temas'] = $this->getLegislacoesPorTipo(2);
-        $legislacao['autores'] = $this->getLegislacoesPorVereador();
-        $legislacao['situacoes'] = $this->getLegislacoesPorSituacao();
+        $especiesNormativas = $legislacaoRepository->getLegislacoesPorTipo(1);
+        $legislacoesTema = $legislacaoRepository->getLegislacoesPorTipo(2);
+        $legislacoesVereador = $legislacaoRepository->getLegislacoesPorVereador();
 
-        $especiesNormativas = $this->getLegislacoesPorTipo(1);
-        $legislacoesTema = $this->getLegislacoesPorTipo(2);
-        $legislacoesVereador = $this->getLegislacoesPorVereador();
+        $legislacao['especiesNormativas'] = $especiesNormativas;
+        $legislacao['temas'] = $legislacoesTema;
+        $legislacao['autores'] = $legislacaoRepository->getLegislacoesPorVereador();
+        $legislacao['situacoes'] = $legislacaoRepository->getLegislacoesPorSituacao();
         
         $filtros = $request->only(['palavraChave', 'numero', 'ano', 'especieNormativa', 'tema', 'autor', 'situacao']);
 
-        $legis = $this->getLegislacoes($filtros);
+        $legis = $legislacaoRepository->get($filtros);
 
         return view('site.legislacao.legislacao', [
             'legislacao' => $legislacao,
@@ -33,72 +30,5 @@ class LegislacaoController extends Controller
             'legislacoesVereador' => $legislacoesVereador,
             'legis' => $legis
         ]);
-    }
-
-    protected function getLegislacoes($filtros)
-    {
-        $query = Legislacao::selectRaw('sitefox_legislacao.*, sitefox_legislacao_situacao.nome, sitefox_vereador.nome vereador')
-            ->join('sitefox_legislacao_situacao', 'sitefox_legislacao.id_situacao', 'sitefox_legislacao_situacao.id')
-            ->join('sitefox_vereador', 'sitefox_legislacao.id_vereador', 'sitefox_vereador.id')
-            ->where('sitefox_legislacao.ativo', 1);
-        
-        return $this->aplicarFiltros($query, $filtros);
-    }
-
-    protected function aplicarFiltros($query, $filtros)
-    {
-        $query->when(data_get($filtros, 'palavraChave'), function ($query) use ($filtros) {
-            $query->where('sitefox_legislacao.ementa', 'like', "%{$filtros['palavraChave']}%");
-        });
-        $query->when(data_get($filtros, 'numero'), function ($query) use ($filtros) {
-            $query->where('sitefox_legislacao.titulo', 'like', "%{$filtros['numero']}%");
-        });
-        $query->when(data_get($filtros, 'ano'), function ($query) use ($filtros) {
-            $query->where('sitefox_legislacao.titulo', 'like', "%{$filtros['ano']}%");
-        });
-        $query->when(data_get($filtros, 'especieNormativa'), function ($query) use ($filtros) {
-            $query->where('sitefox_legislacao.id_tipo', $filtros['especieNormativa']);
-        });
-        $query->when(data_get($filtros, 'tema'), function ($query) use ($filtros) {
-            $query->where('sitefox_legislacao.id_tipo', $filtros['tema']);
-        });
-        $query->when(data_get($filtros, 'autor'), function ($query) use ($filtros) {
-            $query->where('sitefox_legislacao.id_vereador', $filtros['autor']);
-        });
-        $query->when(data_get($filtros, 'situacao'), function ($query) use ($filtros) {
-            $query->where('sitefox_legislacao.id_situacao', $filtros['situacao']);
-        });
-
-        return $query->orderBy('sitefox_legislacao.data_atualizacao', 'desc')
-            ->get();
-    }
-
-    protected function getLegislacoesPorTipo(int $tipo)
-    {
-        return Legislacao::selectRaw('sitefox_legislacao_tipo.nome, sitefox_legislacao_tipo.id, count(sitefox_legislacao_tipo.id) as count')
-        ->join('sitefox_legislacao_tipo', 'sitefox_legislacao.id_tipo', 'sitefox_legislacao_tipo.id')
-        ->groupBy('sitefox_legislacao_tipo.nome')
-        ->groupBy('sitefox_legislacao_tipo.id')
-        ->where('sitefox_legislacao.ativo', 1)
-        ->where('sitefox_legislacao_tipo.tipo', $tipo)
-        ->get();
-    }
-
-    protected function getLegislacoesPorVereador()
-    {
-        return Legislacao::selectRaw('sitefox_vereador.id, sitefox_vereador.nome, count(sitefox_vereador.id) as count')
-        ->join('sitefox_vereador', 'sitefox_legislacao.id_vereador', 'sitefox_vereador.id')
-        ->groupBy('sitefox_vereador.id')
-        ->groupBy('sitefox_vereador.nome')
-        ->get();
-    }
-
-    protected function getLegislacoesPorSituacao()
-    {
-        return Legislacao::selectRaw('sitefox_legislacao_situacao.id, sitefox_legislacao_situacao.nome, count(sitefox_legislacao_situacao.id) as count')
-        ->join('sitefox_legislacao_situacao', 'sitefox_legislacao.id_situacao', 'sitefox_legislacao_situacao.id')
-        ->groupBy('sitefox_legislacao_situacao.id')
-        ->groupBy('sitefox_legislacao_situacao.nome')
-        ->get();
     }
 }

--- a/app/Http/Controllers/Site/legislacao/LegislacaoController.php
+++ b/app/Http/Controllers/Site/legislacao/LegislacaoController.php
@@ -9,70 +9,96 @@ use App\Models\Site\Legislacao;
 use App\Models\Site\LegislacaoSituacao;
 use App\Models\Site\Parlamentar;
 
-
 class LegislacaoController extends Controller
 {
-    public function indexLegislacao(Request $request){
-
-    
-        $parlamentares = Parlamentar::where('sitefox_vereador.ativo', 1)
-                                            ->where('cargo_mesa_diretora', '<>', 'Presidente')
-                                            ->where('id_legislatura', 2)
-                                            ->join('sitefox_vereador_legislatura AS svl', 'sitefox_vereador.id', '=', 'svl.id_vereador')
-                                            ->join('sitefox_legislatura AS sl', 'sl.id', '=', 'svl.id_legislatura')
-                                            ->orderBy('nome')
-                                            ->get();
-
-        
-
-
-        $legislacao['especiesNormativas'] = LegislacaoTipo::where('ativo', true)->where('tipo', 1)->get();
-        $legislacao['temas'] = LegislacaoTipo::where('ativo', true)->where('tipo', 2)->get();
-        $legislacao['autores'] = $parlamentares;
-        $legislacao['situacoes'] = LegislacaoSituacao::orderBy('nome')->where('ativo', 1)->get();
-
-        
-        $especiesNormativas = $this->getLegislacoes(1);
-        $legislacoesTema = $this->getLegislacoes(2);
-        
-        $dadosLegis = $request->input('espNormativa');
-
-        //dd($dadosLegis);
-
-        $legis = $this->getLegislacao(intval($dadosLegis), 1);
-
-        //dd($legis);
-
-
-        return view('site.legislacao.legislacao',['legislacao' => $legislacao,
-                                                 'especiesNormativas'=> $especiesNormativas,
-                                                 'legislacoesTema' => $legislacoesTema,
-                                                  'legis' => $legis]);
-
-    }
-
-    protected function getLegislacao(int $id_tipo, int $tipo)
+    public function indexLegislacao(Request $request)
     {
-        return Legislacao::selectRaw('sitefox_legislacao.titulo, sitefox_legislacao.data_atualizacao, sitefox_legislacao.id_situacao, sitefox_legislacao.indexacao, sitefox_legislacao.ementa, sitefox_legislacao_situacao.nome, sitefox_vereador.nome AS vereador')
-                            ->where('sitefox_legislacao.ativo', 1)
-                            ->join('sitefox_legislacao_tipo', 'sitefox_legislacao.id_tipo', '=', 'sitefox_legislacao_tipo.id')
-                            ->join('sitefox_legislacao_situacao', 'sitefox_legislacao.id_situacao', '=', 'sitefox_legislacao_situacao.id')
-                            ->join('sitefox_vereador', 'sitefox_legislacao.id_vereador', '=', 'sitefox_vereador.id')
-                            ->where('sitefox_legislacao.id_tipo', $id_tipo)
-                            ->where('sitefox_legislacao_tipo.tipo', $tipo)
-                            ->orderBy('sitefox_legislacao.data_atualizacao','desc')
-                            ->get();
+        $legislacao['especiesNormativas'] = $this->getLegislacoesPorTipo(1);
+        $legislacao['temas'] = $this->getLegislacoesPorTipo(2);
+        $legislacao['autores'] = $this->getLegislacoesPorVereador();
+        $legislacao['situacoes'] = $this->getLegislacoesPorSituacao();
+
+        $especiesNormativas = $this->getLegislacoesPorTipo(1);
+        $legislacoesTema = $this->getLegislacoesPorTipo(2);
+        $legislacoesVereador = $this->getLegislacoesPorVereador();
+        
+        $filtros = $request->only(['palavraChave', 'numero', 'ano', 'especieNormativa', 'tema', 'autor', 'situacao']);
+
+        $legis = $this->getLegislacoes($filtros);
+
+        return view('site.legislacao.legislacao', [
+            'legislacao' => $legislacao,
+            'especiesNormativas'=> $especiesNormativas,
+            'legislacoesTema' => $legislacoesTema,
+            'legislacoesVereador' => $legislacoesVereador,
+            'legis' => $legis
+        ]);
     }
 
-    protected function getLegislacoes(int $tipo)
+    protected function getLegislacoes($filtros)
+    {
+        $query = Legislacao::selectRaw('sitefox_legislacao.*, sitefox_legislacao_situacao.nome, sitefox_vereador.nome vereador')
+            ->join('sitefox_legislacao_situacao', 'sitefox_legislacao.id_situacao', 'sitefox_legislacao_situacao.id')
+            ->join('sitefox_vereador', 'sitefox_legislacao.id_vereador', 'sitefox_vereador.id')
+            ->where('sitefox_legislacao.ativo', 1);
+        
+        return $this->aplicarFiltros($query, $filtros);
+    }
+
+    protected function aplicarFiltros($query, $filtros)
+    {
+        $query->when(data_get($filtros, 'palavraChave'), function ($query) use ($filtros) {
+            $query->where('sitefox_legislacao.ementa', 'like', "%{$filtros['palavraChave']}%");
+        });
+        $query->when(data_get($filtros, 'numero'), function ($query) use ($filtros) {
+            $query->where('sitefox_legislacao.titulo', 'like', "%{$filtros['numero']}%");
+        });
+        $query->when(data_get($filtros, 'ano'), function ($query) use ($filtros) {
+            $query->where('sitefox_legislacao.titulo', 'like', "%{$filtros['ano']}%");
+        });
+        $query->when(data_get($filtros, 'especieNormativa'), function ($query) use ($filtros) {
+            $query->where('sitefox_legislacao.id_tipo', $filtros['especieNormativa']);
+        });
+        $query->when(data_get($filtros, 'tema'), function ($query) use ($filtros) {
+            $query->where('sitefox_legislacao.id_tipo', $filtros['tema']);
+        });
+        $query->when(data_get($filtros, 'autor'), function ($query) use ($filtros) {
+            $query->where('sitefox_legislacao.id_vereador', $filtros['autor']);
+        });
+        $query->when(data_get($filtros, 'situacao'), function ($query) use ($filtros) {
+            $query->where('sitefox_legislacao.id_situacao', $filtros['situacao']);
+        });
+
+        return $query->orderBy('sitefox_legislacao.data_atualizacao', 'desc')
+            ->get();
+    }
+
+    protected function getLegislacoesPorTipo(int $tipo)
     {
         return Legislacao::selectRaw('sitefox_legislacao_tipo.nome, sitefox_legislacao_tipo.id, count(sitefox_legislacao_tipo.id) as count')
         ->join('sitefox_legislacao_tipo', 'sitefox_legislacao.id_tipo', 'sitefox_legislacao_tipo.id')
         ->groupBy('sitefox_legislacao_tipo.nome')
         ->groupBy('sitefox_legislacao_tipo.id')
+        ->where('sitefox_legislacao.ativo', 1)
         ->where('sitefox_legislacao_tipo.tipo', $tipo)
         ->get();
     }
 
+    protected function getLegislacoesPorVereador()
+    {
+        return Legislacao::selectRaw('sitefox_vereador.id, sitefox_vereador.nome, count(sitefox_vereador.id) as count')
+        ->join('sitefox_vereador', 'sitefox_legislacao.id_vereador', 'sitefox_vereador.id')
+        ->groupBy('sitefox_vereador.id')
+        ->groupBy('sitefox_vereador.nome')
+        ->get();
+    }
 
+    protected function getLegislacoesPorSituacao()
+    {
+        return Legislacao::selectRaw('sitefox_legislacao_situacao.id, sitefox_legislacao_situacao.nome, count(sitefox_legislacao_situacao.id) as count')
+        ->join('sitefox_legislacao_situacao', 'sitefox_legislacao.id_situacao', 'sitefox_legislacao_situacao.id')
+        ->groupBy('sitefox_legislacao_situacao.id')
+        ->groupBy('sitefox_legislacao_situacao.nome')
+        ->get();
+    }
 }

--- a/app/Models/Site/Legislacao.php
+++ b/app/Models/Site/Legislacao.php
@@ -9,4 +9,5 @@ class Legislacao extends Model
     protected $table = 'sitefox_legislacao';
     
     public $timestamps = false;
+    protected $dates = ['data_atualizacao'];
 }

--- a/app/Repositories/LegislacaoRepository.php
+++ b/app/Repositories/LegislacaoRepository.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\Site\Legislacao;
+
+class LegislacaoRepository
+{
+    public function getLegislacoesPorTipo(int $tipo)
+    {
+        return Legislacao::selectRaw('sitefox_legislacao_tipo.nome, sitefox_legislacao_tipo.id, count(sitefox_legislacao_tipo.id) as count')
+        ->join('sitefox_legislacao_tipo', 'sitefox_legislacao.id_tipo', 'sitefox_legislacao_tipo.id')
+        ->groupBy('sitefox_legislacao_tipo.nome')
+        ->groupBy('sitefox_legislacao_tipo.id')
+        ->where('sitefox_legislacao.ativo', 1)
+        ->where('sitefox_legislacao_tipo.tipo', $tipo)
+        ->get();
+    }
+
+    public function getLegislacoesPorVereador()
+    {
+        return Legislacao::selectRaw('sitefox_vereador.id, sitefox_vereador.nome, count(sitefox_vereador.id) as count')
+        ->join('sitefox_vereador', 'sitefox_legislacao.id_vereador', 'sitefox_vereador.id')
+        ->groupBy('sitefox_vereador.id')
+        ->groupBy('sitefox_vereador.nome')
+        ->get();
+    }
+
+    public function getLegislacoesPorSituacao()
+    {
+        return Legislacao::selectRaw('sitefox_legislacao_situacao.id, sitefox_legislacao_situacao.nome, count(sitefox_legislacao_situacao.id) as count')
+        ->join('sitefox_legislacao_situacao', 'sitefox_legislacao.id_situacao', 'sitefox_legislacao_situacao.id')
+        ->groupBy('sitefox_legislacao_situacao.id')
+        ->groupBy('sitefox_legislacao_situacao.nome')
+        ->get();
+    }
+
+    public function get($filtros)
+    {
+        $query = Legislacao::selectRaw('sitefox_legislacao.*, sitefox_legislacao_situacao.nome, sitefox_vereador.nome vereador')
+            ->join('sitefox_legislacao_situacao', 'sitefox_legislacao.id_situacao', 'sitefox_legislacao_situacao.id')
+            ->join('sitefox_vereador', 'sitefox_legislacao.id_vereador', 'sitefox_vereador.id')
+            ->where('sitefox_legislacao.ativo', 1);
+        
+        return $this->aplicarFiltros($query, $filtros);
+    }
+
+    protected function aplicarFiltros($query, $filtros)
+    {
+        $query->when(data_get($filtros, 'palavraChave'), function ($query) use ($filtros) {
+            $query->where('sitefox_legislacao.ementa', 'like', "%{$filtros['palavraChave']}%");
+        });
+        $query->when(data_get($filtros, 'numero'), function ($query) use ($filtros) {
+            $query->where('sitefox_legislacao.titulo', 'like', "%{$filtros['numero']}%");
+        });
+        $query->when(data_get($filtros, 'ano'), function ($query) use ($filtros) {
+            $query->where('sitefox_legislacao.titulo', 'like', "%{$filtros['ano']}%");
+        });
+        $query->when(data_get($filtros, 'especieNormativa'), function ($query) use ($filtros) {
+            $query->where('sitefox_legislacao.id_tipo', $filtros['especieNormativa']);
+        });
+        $query->when(data_get($filtros, 'tema'), function ($query) use ($filtros) {
+            $query->where('sitefox_legislacao.id_tipo', $filtros['tema']);
+        });
+        $query->when(data_get($filtros, 'autor'), function ($query) use ($filtros) {
+            $query->where('sitefox_legislacao.id_vereador', $filtros['autor']);
+        });
+        $query->when(data_get($filtros, 'situacao'), function ($query) use ($filtros) {
+            $query->where('sitefox_legislacao.id_situacao', $filtros['situacao']);
+        });
+
+        return $query->orderBy('sitefox_legislacao.data_atualizacao', 'desc')
+            ->get();
+    }
+}

--- a/public/css/legislacao/legislacao.css
+++ b/public/css/legislacao/legislacao.css
@@ -1,17 +1,20 @@
 :root {
-    --cor-primaria: #00486F;
-    --gradiente-veradores: linear-gradient(160deg, rgba(0,72,111,1) 0%, rgba(255,255,255,1) 55%);
+    --cor-primaria: #00486f;
+    --gradiente-veradores: linear-gradient(
+        160deg,
+        rgba(0, 72, 111, 1) 0%,
+        rgba(255, 255, 255, 1) 55%
+    );
     --sombra: rgba(0, 0, 0, 0.35) 0px 5px 15px;
 }
 
-
-.card{
+.card {
     margin: 4% 0%;
 }
 
-.card_cabecalho{
+.card_cabecalho {
     background-color: var(--cor-primaria) !important;
-    color:#fff;
+    color: #fff;
     border-radius: 5px 5px 0px 0px !important;
 }
 
@@ -28,12 +31,4 @@
 
 .box_licitacao p {
     text-align: center;
-}
-
-.dados_header{
-    display: flex;
-}
-
-.dados_header p {
-    margin-right: 15%;
 }

--- a/public/css/sessao6.css
+++ b/public/css/sessao6.css
@@ -3,20 +3,23 @@
 }
 
 .box {
-    background-color: #e9e9e9; 
+    background-color: #e9e9e9;
     border-radius: 15px;
     padding: 0px;
     width: 100%;
-    height: 95%;
     max-width: 550px;
     margin-top: 15px;
     margin-bottom: 15px;
 }
 
+.box-height {
+    height: 95%;
+}
+
 .box-titulo {
     background-color: #00486f;
     text-align: center;
-    margin-bottom: 18px;
+    padding-bottom: 18px;
     color: #fff;
     border-radius: 15px 15px 0 0;
     width: 100%;
@@ -49,5 +52,5 @@
 }
 
 .home-item:hover {
-    background-color: #ebe3e3 !important;
+    background-color: #969090 !important;
 }

--- a/resources/views/layouts/site_layout.blade.php
+++ b/resources/views/layouts/site_layout.blade.php
@@ -27,7 +27,7 @@
     <link href="{{ asset('css/sessao7.css') }}" rel="stylesheet">
     <link href="{{ asset('css/noticia.css') }}" rel="stylesheet">
     <link href="{{ asset('css/page_noticias.css') }}" rel="stylesheet">
-    
+
     <!--Licitacao-->
     <link href="{{ asset('css/legislacao/legislacao.css') }}" rel="stylesheet">
 
@@ -36,6 +36,7 @@
     <link href="{{ asset('css/estrutura_interna.css') }}" rel="stylesheet">
     <link href="{{ asset('css/estrutura_interna_mobile.css') }}" rel="stylesheet">
     <link href="{{ asset('fontawesome/css/all.css') }}" rel="stylesheet">
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
     @yield('css')
     <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.9.0/css/bootstrap-datepicker.min.css"
         rel="stylesheet">
@@ -79,7 +80,8 @@
                             </div>
 
                             <div class="itn_area_campos_login itn_recuperar_login_senha sw_lato_bold">Esqueci minha
-                                <span id="link_senha" class="sw_lato_bold">senha</span></div>
+                                <span id="link_senha" class="sw_lato_bold">senha</span>
+                            </div>
 
                             <div class="itn_area_campos_login itn_area_campos_login_recaptcha">
                                 <div class="g-recaptcha-login" id="captchaLogin"></div>

--- a/resources/views/site/home-sessao6.blade.php
+++ b/resources/views/site/home-sessao6.blade.php
@@ -1,5 +1,3 @@
-<!----- SESSAO 6 ----->
-
 <div class="row">
     <div class="col-12">
         <div class="noticias_titulo">
@@ -10,20 +8,23 @@
     </div>
 </div>
 
-<div class="row sessao6">       
+<div class="row sessao6">
     <div class="col-md-4">
         <div class="box">
             <div class="box-titulo">Legislação</div>
 
-            <form class="form" method="post" action="{{route('legislacao.legislacao')}}">
+            <form class="form" method="post" action="{{ route('legislacao.legislacao') }}">
+                @csrf
                 <div class="input-group mb-3">
-                    <span class="input-group-text" id="basic-addon1"><i class="fa fa-search ico-legis" aria-hidden="true"></i></span>
+                    <span class="input-group-text" id="basic-addon1"><i class="fa fa-search ico-legis"
+                            aria-hidden="true"></i></span>
                     <input type="text" class="form-control" name="palavraChave" placeholder="Palavra chave">
-                </div>                 
+                </div>
                 <div class="row">
                     <div class="col-md-8">
                         <div class="input-group mb-3">
-                            <input type="number" class="form-control inp-text" name="numero" placeholder="Número" value="">
+                            <input type="number" class="form-control inp-text" name="numero" placeholder="Número"
+                                value="">
                         </div>
                     </div>
                     <div class="col-md-4">
@@ -36,9 +37,10 @@
                     <div class="col-md-12">
                         <div class="input-group mb-3">
                             <select name="especieNormativa" class="form-select">
-                                <option selected>Selecione uma espécie normativa</option>
+                                <option value="">Selecione uma espécie normativa</option>
                                 @foreach ($legislacao['especiesNormativas'] as $especieNormativa)
-                                    <option value="{{$especieNormativa->id}}">{{$especieNormativa->nome}}</option>
+                                    <option value="{{ $especieNormativa->id }}">{{ $especieNormativa->nome }}
+                                    </option>
                                 @endforeach
                             </select>
                         </div>
@@ -48,9 +50,9 @@
                     <div class="col-md-12">
                         <div class="input-group mb-3">
                             <select name="tema" class="form-select">
-                                <option selected>Selecione um tema</option>
+                                <option value="">Selecione um tema</option>
                                 @foreach ($legislacao['temas'] as $tema)
-                                    <option value="{{$tema->id}}">{{$tema->nome}}</option>
+                                    <option value="{{ $tema->id }}">{{ $tema->nome }}</option>
                                 @endforeach
                             </select>
                         </div>
@@ -60,9 +62,9 @@
                     <div class="col-md-12">
                         <div class="input-group mb-3">
                             <select name="autor" class="form-select">
-                                <option selected>Selecione um autor</option>
+                                <option value="">Selecione um autor</option>
                                 @foreach ($legislacao['autores'] as $autor)
-                                    <option value="{{$autor->id}}">{{$autor->nome}}</option>
+                                    <option value="{{ $autor->id }}">{{ $autor->nome }}</option>
                                 @endforeach
                             </select>
                         </div>
@@ -71,10 +73,10 @@
                 <div class="row">
                     <div class="col-md-12">
                         <div class="input-group mb-3">
-                            <select name="autor" class="form-select">
-                                <option selected>Selecione uma situação</option>
+                            <select name="situacao" class="form-select">
+                                <option value="">Selecione uma situação</option>
                                 @foreach ($legislacao['situacoes'] as $situacao)
-                                    <option value="{{$situacao->id}}">{{$situacao->nome}}</option>
+                                    <option value="{{ $situacao->id }}">{{ $situacao->nome }}</option>
                                 @endforeach
                             </select>
                         </div>
@@ -88,31 +90,33 @@
     </div>
 
     <div class="col-md-4">
-        <div class="box">
+        <div class="box box-height">
             <div class="box-titulo">Espécies Normativas</div>
 
             <div class="list-group">
                 @foreach ($especiesNormativas as $item)
-                    <a href="#" class="home-item list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+                    <a href="{{ route('legislacao.legislacao', ['especieNormativa' => $item->id]) }}"
+                        class="home-item list-group-item list-group-item-action d-flex justify-content-between align-items-center">
                         {{ $item->nome }}
                         <span class="badge home-bg-primary rounded-pill">{{ $item->count }}</span>
                     </a>
-                @endforeach                
+                @endforeach
             </div>
         </div>
     </div>
 
     <div class="col-md-4">
-        <div class="box">
+        <div class="box box-height">
             <div class="box-titulo">Legislação por Tema</div>
 
             <div class="list-group">
                 @foreach ($legislacoesTema as $item)
-                    <a href="#" class="home-item list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+                    <a href="{{ route('legislacao.legislacao', ['tema' => $item->id]) }}"
+                        class="home-item list-group-item list-group-item-action d-flex justify-content-between align-items-center">
                         {{ $item->nome }}
                         <span class="badge home-bg-primary rounded-pill">{{ $item->count }}</span>
                     </a>
-                @endforeach                
+                @endforeach
             </div>
         </div>
     </div>

--- a/resources/views/site/legislacao/legislacao.blade.php
+++ b/resources/views/site/legislacao/legislacao.blade.php
@@ -1,153 +1,173 @@
 @extends('layouts.site_layout')
 
-
 @section('content')
+    <div class="container">
+        <div class="row">
+            <div class="col-sm-12 col-md-4">
+                <div class="box_licitacao">
+                    <div class="box-titulo">Busca</div>
+                    <p>Escolha uma das consultas e acesse esta ferramenta de transparência do Poder Público.</p>
+                    <form class="form" name="formLegislacao" id="formLegislacao" method="post" action="">
+                        @csrf
+                        <div class="input-group mb-3">
+                            <span class="input-group-text" id="basic-addon1"><i class="fa fa-search ico-legis"
+                                    aria-hidden="true"></i></span>
+                            <input type="text" class="form-control" name="palavraChave" id="palavraChave"
+                                placeholder="Palavra chave">
+                        </div>
+                        <div class="row">
+                            <div class="col-md-8">
+                                <div class="input-group mb-3">
+                                    <input type="number" class="form-control inp-text" name="numero" placeholder="Número"
+                                        value="">
+                                </div>
+                            </div>
+                            <div class="col-md-4">
+                                <div class="input-group mb-3">
+                                    <input type="number" class="form-control inp-text" name="ano" placeholder="Ano"
+                                        value="">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-12">
+                                <div class="input-group mb-3">
+                                    <select name="especieNormativa" class="form-select" id="especieNormativa">
+                                        <option value="">Selecione uma espécie normativa</option>
+                                        @foreach ($legislacao['especiesNormativas'] as $especieNormativa)
+                                            <option value="{{ $especieNormativa->id }}">{{ $especieNormativa->nome }}
+                                            </option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-12">
+                                <div class="input-group mb-3">
+                                    <select name="tema" class="form-select" id="tema">
+                                        <option value="">Selecione um tema</option>
+                                        @foreach ($legislacao['temas'] as $tema)
+                                            <option value="{{ $tema->id }}">{{ $tema->nome }}</option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-12">
+                                <div class="input-group mb-3">
+                                    <select name="autor" class="form-select" id="autor">
+                                        <option value="">Selecione um autor</option>
+                                        @foreach ($legislacao['autores'] as $autor)
+                                            <option value="{{ $autor->id }}">{{ $autor->nome }}</option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-12">
+                                <div class="input-group mb-3">
+                                    <select name="situacao" class="form-select" id="situacao">
+                                        <option value="">Selecione uma situação</option>
+                                        @foreach ($legislacao['situacoes'] as $situacao)
+                                            <option value="{{ $situacao->id }}">{{ $situacao->nome }}</option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="btn-group" role="group">
+                            <button type="submit" class="btn btn-primary box-btn">Pesquisar</button>
+                        </div>
+                    </form>
+                </div>
 
-<div class="container">
-    <div class="row">        
-        <div class="col-4">
-            <div class="box_licitacao">
-                <div class="box-titulo">Busca</div>
-                <p>Escolha uma das consultas e acesse esta ferramenta de transparência do Poder Público.</p>
-                <form class="form" name="formLegislacao" id="formLegislacao"  method="post" action="{{route('legislacao.legislacao')}}">
-                    @csrf
-                    <div class="input-group mb-3">
-                        <span class="input-group-text" id="basic-addon1"><i class="fa fa-search ico-legis" aria-hidden="true"></i></span>
-                        <input type="text" class="form-control" name="palavraChave"  id="palavraChave" placeholder="Palavra chave">
-                    </div>                 
-                    <div class="row">
-                        <div class="col-md-8">
-                            <div class="input-group mb-3">
-                                <input type="number" class="form-control inp-text" name="numero" placeholder="Número" value="">
+                <div class="box">
+                    <div class="box-titulo">Espécies Normativas</div>
+                    <div class="list-group">
+                        @foreach ($especiesNormativas as $item)
+                            <a href="{{ route('legislacao.legislacao', ['especieNormativa' => $item->id]) }}"
+                                class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+                                {{ $item->nome }}
+                                <span class="badge home-bg-primary rounded-pill">{{ $item->count }}</span>
+                            </a>
+                        @endforeach
+                    </div>
+                </div>
+
+                <div class="box">
+                    <div class="box-titulo">Legislação por Tema</div>
+                    <div class="list-group">
+                        @foreach ($legislacoesTema as $item)
+                            <a href="{{ route('legislacao.legislacao', ['tema' => $item->id]) }}"
+                                class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+                                {{ $item->nome }}
+                                <span class="badge home-bg-primary rounded-pill">{{ $item->count }}</span>
+                            </a>
+                        @endforeach
+                    </div>
+                </div>
+
+                <div class="box">
+                    <div class="box-titulo">Legislação por Vereador</div>
+                    <div class="list-group">
+                        @foreach ($legislacoesVereador as $item)
+                            <a href="{{ route('legislacao.legislacao', ['autor' => $item->id]) }}"
+                                class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+                                {{ $item->nome }}
+                                <span class="badge home-bg-primary rounded-pill">{{ $item->count }}</span>
+                            </a>
+                        @endforeach
+                    </div>
+                </div>
+            </div>
+
+            <!--CARDS COM AS LEGISLAÇÕES-->
+            <div class="col-sm-12 col-md">
+                <p class="mt-3">
+                    Este Portal disponibiliza o Banco de Dados de Normas Jurídicas do Município.
+                    Por meio de consultas rápidas e práticas, o cidadão terá acesso à íntegra de toda a Legislação Municipal
+                    vigente.
+                </p>
+                @foreach ($legis as $leg)
+                    <div class="card">
+                        <div class="card-header card_cabecalho">
+                            {{ $leg->titulo }}
+                        </div>
+                        <div class="card-body">
+                            <div class="row">
+                                <div class="col">
+                                    <p class=""><b>Data:</b>
+                                        {{ $leg->data_atualizacao->format('d/m/Y') }}
+                                    </p>
+                                </div>
+                                <div class="col">
+                                    <p class=""><b>Situação:</b> {{ $leg->nome }}</p>
+                                </div>
+                                <div class="col">
+                                    <p class=""><b>Tema:</b> {{ $leg->indexacao }}</p>
+                                </div>
+                                <div class="col">
+                                    <div class="d-flex justify-content-end">
+                                        <a href={{ url(str_replace(' ', '%20', $leg->arquivo)) }}
+                                            class="btn btn-default btn-sm" target="_blank" title="Visualizar">
+                                            <i class="fa fa-file-pdf-o fa-lg" aria-hidden="true"></i>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="">
+                                <p><b>Assunto:</b> {{ $leg->ementa }}</p>
                             </div>
                         </div>
-                        <div class="col-md-4">
-                            <div class="input-group mb-3">
-                                <input type="number" class="form-control inp-text" name="ano" placeholder="Ano" value="">
-                            </div>
+                        <div class="card-footer text-muted">
+                            <p><b>Autor: {{ $leg->vereador }}</b></p>
                         </div>
                     </div>
-                    <div class="row">
-                        <div class="col-md-12">
-                            <div class="input-group mb-3">
-                                <select name="espNormativa" class="form-select" id="espNormativa">
-                                    <option value="0">Selecione uma espécie normativa</option>
-                                    @foreach ($legislacao['especiesNormativas'] as $especieNormativa)
-                                        <option value="{{$especieNormativa->id}}">{{$especieNormativa->nome}}</option>
-                                    @endforeach
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-md-12">
-                            <div class="input-group mb-3">
-                                <select name="tema" class="form-select" id="tema">
-                                    <option value="0">Selecione um tema</option>
-                                    @foreach ($legislacao['temas'] as $tema)
-                                        <option value="{{$tema->id}}">{{$tema->nome}}</option>
-                                    @endforeach
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-md-12">
-                            <div class="input-group mb-3">
-                                <select name="autor" class="form-select" id="autor">
-                                    <option value="0">Selecione um autor</option>
-                                    @foreach ($legislacao['autores'] as $autor)
-                                        <option value="{{$autor->id}}">{{$autor->nome}}</option>
-                                    @endforeach
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-md-12">
-                            <div class="input-group mb-3">
-                                <select name="situacao" class="form-select" id="situacao">
-                                    <option value="0">Selecione uma situação</option>
-                                    @foreach ($legislacao['situacoes'] as $situacao)
-                                        <option value="{{$situacao->id}}">{{$situacao->nome}}</option>
-                                    @endforeach
-                                </select>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="btn-group" role="group">
-                        <button type="submit" class="btn btn-primary box-btn">Pesquisar</button>
-                    </div>
-                </form>
+                @endforeach
             </div>
         </div>
-        
-        <!--CARDS COM AS LEGISLAÇÕES-->
-        <div class="col-8">
-            <p>Este Portal disponibiliza o Banco de Dados de Normas Jurídicas do Município. 
-               Por meio de consultas rápidas e práticas, o cidadão terá acesso à íntegra de toda a Legislação Municipal vigente.
-            </p>
-
-            @foreach ($legis as $leg)
-
-            <div class="card">
-                <div class="card-header card_cabecalho">
-                  {{$leg->titulo}}
-                </div>
-                <div class="card-body">
-                    <div class="dados_header">
-                        <p><b>Data:</b> {{$leg->data_atualizacao}}</p>
-                        <p><b>Situação:</b> {{$leg->nome}}</p>
-                        <p><b>Tema:</b> {{$leg->indexacao}}</p>
-                    </div>
-                    <div class="card_texto">
-                        <p><b>Assunto:</b> {{ $leg->ementa }}</p>
-                    </div>
-
-                </div>
-                <div class="card-footer text-muted">
-                    <p><b>Autor: {{ $leg->vereador}}</b></p>
-                </div>
-              </div>
-            
-                
-            @endforeach
-            
-        </div>
     </div>
-</div>
-
- <script>
-     /*
-     $(function(){
-        $('#formLegislacao').submit(function(event){
-            event.preventDefault();
-
-            var palavraChave = $(this).find('#palavraChave').val();
-            var especieNormativa = $(this).find('#especieNormativa').val();
-            //alert('ok');
-        });
-        var url = "{{route('legislacao.legislacao')}}";
-
-        $.ajax({
-            headers: {
-                'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')},
-
-            url: url,
-            type: 'post',
-            dataType: "json",   
-            data: {
-                palavraChave: palavraChave,
-                especieNormativa: especieNormativa 
-            }
-        })
-
-     });
-
-     */
-    
-
- </script>
-
-
 @endsection


### PR DESCRIPTION
**Por que os cards de legislações não estão sendo exibidos?**
- no nosso banco de dados na tabela sitefox_legislacao os valores da coluna id_vereador estão negativos, como a gente faz join da tabela sitefox_legislacao com sitefox_vereador nenhum registro é retornado, pois na sitefox_vereador não existe id negativo.
- para resolver rodei o comando (tem que ver se o banco que está em produção está com esse problema): update sitefox_legislacao set id_vereador = id_vereador * -1 where id_vereador < 0

**Observações:**
- nessa demanda faltou fazer a paginação dos dados.
- coloquei o link dos cards relacionados a Legislação da home, agora o formulário e os filtros estão funcionando.
- implementei a página de legislação com configurações de responsividade para adaptar a outros tamanhos de tela.

@gereiz no projeto os arquivos estão salvos na pasta public/fotos. Não sei se você sabe como funciona essa questão dos arquivos locais no Laravel. Se quiser podemos fazer uma chamada rápida que posso te explicar, porque depois quando for implementar o salvamento dos arquivos, você não conseguirá salvar diretamente nessa pasta public da raíz.

**Sugestões**

- existem aquivos com espaço no nome, por isso precisei colocar um str_replace no link para abrir os arquivos. Seria interessante ter uma tabela de arquivos para salvar o nome e um hash, e salvar o arquivo no disco com o nome do hash.
- trocar a primeira letra maiúscula das rotas Noticias e Legislacao. 
- o menu principal está sumindo quando a tela é redimensionada.

Prints:

![Screenshot from 2022-02-19 19-43-18](https://user-images.githubusercontent.com/48796118/154821604-20899429-9d69-4835-8c31-794b3dd846eb.png)

![Screenshot from 2022-02-19 19-43-32](https://user-images.githubusercontent.com/48796118/154821614-078b5499-ee8f-477c-8947-5892e7899c42.png)


